### PR TITLE
Create API for mood/genre pairings

### DIFF
--- a/movie-app/functions/fetch-mood/fetch-mood.js
+++ b/movie-app/functions/fetch-mood/fetch-mood.js
@@ -1,0 +1,21 @@
+const axios = require('axios');
+
+const handler = async (event) => {
+  const { genreId } = event.queryStringParameters;
+  const API_KEY = `api_key=${process.env.API_KEY}`;
+  const BASE_URL = 'https://api.themoviedb.org/3';
+  const url = `${BASE_URL}/discover/movie?${API_KEY}&with_genres=${genreId}`;
+
+  try {
+    const { data } = await axios.get(url);
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify(data),
+    };
+  } catch (err) {
+    console.log(err);
+  }
+};
+
+module.exports = { handler };

--- a/movie-app/functions/fetch-movie-mood/fetch-movie-mood.js
+++ b/movie-app/functions/fetch-movie-mood/fetch-movie-mood.js
@@ -1,10 +1,10 @@
 const axios = require('axios');
 
 const handler = async (event) => {
-  const { genreId } = event.queryStringParameters;
+  const { moodId } = event.queryStringParameters;
   const API_KEY = `api_key=${process.env.API_KEY}`;
   const BASE_URL = 'https://api.themoviedb.org/3';
-  const url = `${BASE_URL}/discover/movie?${API_KEY}&with_genres=${genreId}`;
+  const url = `${BASE_URL}/discover/movie?${API_KEY}&language=en-US&include_adult=false&with_genres=${moodId}`;
 
   try {
     const { data } = await axios.get(url);

--- a/movie-app/src/components/MoodButtons.js
+++ b/movie-app/src/components/MoodButtons.js
@@ -1,0 +1,66 @@
+import { Grid, Button } from '@mui/material';
+import movieMoods from '../data';
+
+function MoodButtons({ setUrl }) {
+  return (
+    <Grid container direction="row" spacing={2}>
+      <Grid item>
+        <Button
+          variant="contained"
+          color="secondary"
+          onClick={() => {
+            setUrl(`/api/fetch-trending-all`);
+          }}
+        >
+          Trending
+        </Button>
+      </Grid>
+      <Grid item>
+        <Button
+          variant="contained"
+          color="secondary"
+          onClick={() => {
+            setUrl(`/api/fetch-movie-mood?moodId=${movieMoods.funny}`);
+          }}
+        >
+          Funny
+        </Button>
+      </Grid>
+      <Grid item>
+        <Button
+          variant="contained"
+          color="secondary"
+          onClick={() => {
+            setUrl(`/api/fetch-movie-mood?moodId=${movieMoods.romantic}`);
+          }}
+        >
+          Romantic
+        </Button>
+      </Grid>
+      <Grid item>
+        <Button
+          variant="contained"
+          color="secondary"
+          onClick={() => {
+            setUrl(`/api/fetch-movie-mood?moodId=${movieMoods.dark}`);
+          }}
+        >
+          Dark
+        </Button>
+      </Grid>
+      <Grid item>
+        <Button
+          variant="contained"
+          color="secondary"
+          onClick={() => {
+            setUrl(`/api/fetch-movie-mood?moodId=${movieMoods.excited}`);
+          }}
+        >
+          Excited
+        </Button>
+      </Grid>
+    </Grid>
+  );
+}
+
+export default MoodButtons;

--- a/movie-app/src/components/MovieRow.js
+++ b/movie-app/src/components/MovieRow.js
@@ -6,9 +6,10 @@ import Grid from '@mui/material/Grid';
 import Modal from '@mui/material/Modal';
 import Box from '@mui/material/Box';
 import useFetch from '../hooks/useFetch';
+import MoodButtons from './MoodButtons';
 
 function MovieRow({ title }) {
-  const url = '/api/fetch-trending-all';
+  const [url, setUrl] = useState(`/api/fetch-trending-all`);
   const {
     data: { results: movie },
     error,
@@ -37,13 +38,14 @@ function MovieRow({ title }) {
 
   return (
     <Container fixed>
+      <Typography component="h1" variant="h5">
+        {title}
+      </Typography>
+      <MoodButtons setUrl={setUrl} />
       {isLoading ? (
         'Loading...'
       ) : (
         <>
-          <Typography component="h1" variant="h5">
-            {title}
-          </Typography>
           {movie ? (
             <Grid container rowSpacing={0.5} columnSpacing={{ xs: 1, sm: 1, md: 1 }}>
               {movie.map((movie) => (

--- a/movie-app/src/data/index.js
+++ b/movie-app/src/data/index.js
@@ -7,7 +7,7 @@ const getGenreMoodPairings = () => {
   return {
     funny: `${comedy},${adventure}`,
     romantic: `${romance}`,
-    dark: `${crime},${thriller}`,
+    dark: `${crime},${thriller},${mystery}`,
     tense: `${thriller},${mystery},${horror}`,
     excited: `${action},${adventure}`,
     blissful: `${fantasy},${animation},${family}`,

--- a/movie-app/src/data/index.js
+++ b/movie-app/src/data/index.js
@@ -1,45 +1,9 @@
-const movieGenres = {
-  action: 28,
-  adventure: 12,
-  animation: 16,
-  comedy: 35,
-  crime: 80,
-  documentary: 99,
-  drama: 18,
-  family: 10751,
-  fantasy: 14,
-  history: 36,
-  horror: 27,
-  music: 10402,
-  mystery: 9648,
-  romance: 10749,
-  scienceFiction: 878,
-  tvMovie: 10770,
-  thriller: 53,
-  war: 10752,
-  western: 37,
-};
+// prettier-ignore
+const movieGenres = { action: 28, adventure: 12, animation: 16, comedy: 35, crime: 80, documentary: 99, drama: 18, family: 10751, fantasy: 14, history: 36, horror: 27, music: 10402, mystery: 9648, romance: 10749, scienceFiction: 878, tvMovie: 10770, thriller: 53, war: 10752, western: 37 };
 
+// prettier-ignore
 const getGenreMoodPairings = () => {
-  const {
-    action,
-    adventure,
-    animation,
-    comedy,
-    crime,
-    documentary,
-    drama,
-    family,
-    fantasy,
-    history,
-    horror,
-    music,
-    mystery,
-    romance,
-    scienceFiction,
-    thriller,
-    war,
-  } = movieGenres;
+  const { action, adventure, animation, comedy, crime, documentary, drama, family, fantasy, history, horror, music, mystery, romance, scienceFiction, thriller, war } = movieGenres;
   return {
     funny: `${comedy},${adventure}`,
     romantic: `${romance}`,

--- a/movie-app/src/data/index.js
+++ b/movie-app/src/data/index.js
@@ -1,0 +1,59 @@
+const movieGenres = {
+  action: 28,
+  adventure: 12,
+  animation: 16,
+  comedy: 35,
+  crime: 80,
+  documentary: 99,
+  drama: 18,
+  family: 10751,
+  fantasy: 14,
+  history: 36,
+  horror: 27,
+  music: 10402,
+  mystery: 9648,
+  romance: 10749,
+  scienceFiction: 878,
+  tvMovie: 10770,
+  thriller: 53,
+  war: 10752,
+  western: 37,
+};
+
+const getGenreMoodPairings = () => {
+  const {
+    action,
+    adventure,
+    animation,
+    comedy,
+    crime,
+    documentary,
+    drama,
+    family,
+    fantasy,
+    history,
+    horror,
+    music,
+    mystery,
+    romance,
+    scienceFiction,
+    thriller,
+    war,
+  } = movieGenres;
+  return {
+    funny: `${comedy},${adventure}`,
+    romantic: `${romance}`,
+    dark: `${crime},${thriller}`,
+    tense: `${thriller},${mystery},${horror}`,
+    excited: `${action},${adventure}`,
+    blissful: `${fantasy},${animation},${family}`,
+    historic: `${war},${history}`,
+    emotional: `${drama},${romance},${mystery}`,
+    curious: `${documentary}`,
+    thoughtProvoking: `${mystery},${scienceFiction},${adventure}`,
+    musical: `${music},${comedy},${romance}`,
+  };
+};
+
+const movieMoods = getGenreMoodPairings();
+export default movieMoods;


### PR DESCRIPTION
- Added `movieMoods` object which returns corresponding `genre_id`. Example: `movieMoods.funny = '35,12'`
- Added Netlify function `fetch-movie-mood` which takes in a list of `genre_id`, i.e.: `'35,12'`, fetch and return a list of movies
  - This function can be called via endpoint `/api/fetch-movie-mood` and add `genre_id`(number) after `?moodId=`
  - Example of Funny endpoint: `/api/fetch-movie-mood?moodId=35,12`
- Added buttons to filter Trending, Funny, Romantic, etc.