### PR TITLE
Fix Modal Behavior 

### DIFF
--- a/movie-app/src/components/MovieRow.js
+++ b/movie-app/src/components/MovieRow.js
@@ -61,8 +61,9 @@ function MovieRow({ title, data: movies, isLoading, error }) {
           <Modal open={open} onClose={handleClose}>
             <Box sx={style}>
               <img
-                src={`https://image.tmdb.org/t/p/original/${selectedMovie.backdrop_path}`}
-                alt="modal-img"
+                src={`https://image.tmdb.org/t/p/w300/${selectedMovie.backdrop_path}`}
+                alt={`${selectedMovie.title}'s Banner`}
+                loading="lazy"
                 style={{ width: '100%' }}
               />
               <Typography id="modal-modal-title" variant="h6" component="h2">

--- a/movie-app/src/components/MovieRow.js
+++ b/movie-app/src/components/MovieRow.js
@@ -5,7 +5,7 @@ import Modal from '@mui/material/Modal';
 import Box from '@mui/material/Box';
 import './MovieRow.css';
 import { isValid } from '../data';
-import { Link } from '@mui/material';
+import { Button } from '@mui/material';
 import { Link as RouterLink } from 'react-router-dom';
 
 function MovieRow({ title, data: movies, isLoading, error }) {
@@ -24,9 +24,7 @@ function MovieRow({ title, data: movies, isLoading, error }) {
     transform: 'translate(-50%, -50%)',
     width: 400,
     bgcolor: 'background.paper',
-    border: '2px solid #000',
     boxShadow: 24,
-    p: 4,
   };
 
   return (
@@ -66,24 +64,26 @@ function MovieRow({ title, data: movies, isLoading, error }) {
                 loading="lazy"
                 style={{ width: '100%' }}
               />
-              <Typography id="modal-modal-title" variant="h6" component="h2">
-                {selectedMovie.title ? selectedMovie.title : selectedMovie.name}
-              </Typography>
-              <Typography id="modal-modal-description">{selectedMovie.overview}</Typography>
-              <Typography>
-                {selectedMovie.release_date
-                  ? selectedMovie.release_date
-                  : selectedMovie.first_air_date}
-              </Typography>
-              <Typography>vote_average : {selectedMovie.vote_average}</Typography>
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5, p: 4, pt: 1.5 }}>
+                <Typography id="modal-modal-title" variant="h4" component="h2">
+                  {selectedMovie.title ? selectedMovie.title : selectedMovie.name}
+                </Typography>
+                <Typography id="modal-modal-description">{selectedMovie.overview}</Typography>
+                <Typography>
+                  {selectedMovie.release_date
+                    ? selectedMovie.release_date
+                    : selectedMovie.first_air_date}
+                </Typography>
+                <Typography>vote_average : {selectedMovie.vote_average}</Typography>
                 <Button
                   variant="contained"
                   component={RouterLink}
                   to={`/movie/${selectedMovie.id}`}
                   onClick={handleClose}
                 >
-                View Details
-              </Link>
+                  View Details
+                </Button>
+              </Box>
             </Box>
           </Modal>
         </>

--- a/movie-app/src/components/MovieRow.js
+++ b/movie-app/src/components/MovieRow.js
@@ -76,7 +76,12 @@ function MovieRow({ title, data: movies, isLoading, error }) {
                   : selectedMovie.first_air_date}
               </Typography>
               <Typography>vote_average : {selectedMovie.vote_average}</Typography>
-              <Link variant="button" component={RouterLink} to={`/movie/${selectedMovie.id}`}>
+                <Button
+                  variant="contained"
+                  component={RouterLink}
+                  to={`/movie/${selectedMovie.id}`}
+                  onClick={handleClose}
+                >
                 View Details
               </Link>
             </Box>


### PR DESCRIPTION
- Reduced banner size for faster loading time
- Modal will now close after clicking "View Detail"
- Minor style adjustments:
   - Banner now spans across modal element
   - Add spacing
   - "View Detail" is now a button